### PR TITLE
Add dithering flag for Spectra6

### DIFF
--- a/src/bb_ep_gfx.inl
+++ b/src/bb_ep_gfx.inl
@@ -467,6 +467,15 @@ void bbepSetPixelFast16Clr(void *pb, int x, int y, unsigned char ucColor)
     uint8_t u8;
     BBEPDISP *pBBEP = (BBEPDISP *)pb;
     
+    if (ucColor & BBEP_DITHERING_FLAG) {
+        // if dithering requested, unset the bit to get the correct color
+        ucColor &= ~BBEP_DITHERING_FLAG;
+        if (x % 2 == (y % 2 == 0) ? 0 : 1) {
+            // skip pixel
+            return;
+        }
+    }
+
     iPitch = pBBEP->width >> 1;
     i = (x >> 1) + (y * iPitch);
     u8 = pBBEP->ucScreen[i];

--- a/src/bb_epaper.h
+++ b/src/bb_epaper.h
@@ -193,6 +193,8 @@ enum {
 #define BBEP_SPECTRA_ORANGE  0x06
 #define BBEP_SPECTRA_CLEAN   0x07
 
+#define BBEP_DITHERING_FLAG   0x80 //if set, draws a 2x2 dithering pattern (every second pixels skipped)
+
 // 4 gray levels
 #define BBEP_GRAY0 0
 #define BBEP_GRAY1 1


### PR DESCRIPTION
Another option would be to add another `bbepSetPixelFast16Clr` if performance is a concern (I don't think so as internal refresh rate is around 15s).