### PR TITLE
Fix compile on rpi_pico #4

### DIFF
--- a/rpi_pico/pico_io.inl
+++ b/rpi_pico/pico_io.inl
@@ -103,7 +103,7 @@ void I2CInit(uint32_t iSpeed)
     gpio_pull_up(I2C_SCL);
  }
 
-static void bbepWriteData(BBEPDISP *pBBEP, uint8_t *pData, int iLen)
+void bbepWriteData(BBEPDISP *pBBEP, uint8_t *pData, int iLen)
 {
       digitalWrite(pBBEP->iCSPin, LOW);
       spi_write_blocking(spi0, pData, iLen);


### PR DESCRIPTION
This PR corrects #4.

The the compile error was
```
/home/skip/esl/bb_epaper/rpi_pico/epaper_example/../pico_io.inl:106:13 Kerror: static declaration of 'bbepWriteData' follows non-static declaration
```

None of the other implementations are declared as static.