### PR TITLE
Changes to allow bb_epaper library to be used on bare metal.

### DIFF
--- a/src/bb_ep.inl
+++ b/src/bb_ep.inl
@@ -1478,6 +1478,11 @@ const uint8_t epd81c_init_full[] PROGMEM = {
     0x00
 };
 
+#ifndef _BB_EPAPER_CPP_
+// needed by some linkers that don't allow the same global to be defined
+// in multiple .c / .cpp source files.
+extern
+#endif
 #ifdef NO_RAM
 uint8_t u8Cache[128]; // buffer a single line of up to 1024 pixels
 #else // we need a larger cache for 4-bit panels

--- a/src/bb_epaper.cpp
+++ b/src/bb_epaper.cpp
@@ -31,8 +31,14 @@ void delay(int);
 
 #endif // _LINUX_
 
+#define _BB_EPAPER_CPP_
 #include "bb_epaper.h"
-#ifdef _LINUX_
+
+#ifdef _CUSTOM_IO_
+#define xstr(s) str(s)
+#define str(s) #s
+#include xstr(_CUSTOM_IO_)
+#elif defined _LINUX_
 #include "rpi_io.inl"
 #else
 #include "arduino_io.inl" // I/O (non-portable) code is in here

--- a/src/bb_epaper.h
+++ b/src/bb_epaper.h
@@ -396,7 +396,7 @@ BB_SET_PIXEL_FAST *pfnSetPixelFast;
 } BBEPDISP;
 
 #ifdef __cplusplus
-#if defined( _LINUX_ )
+#if defined _LINUX_ || defined _CUSTOM_IO_
 #include <string>
 using namespace std;
 class BBEPAPER
@@ -475,7 +475,7 @@ class BBEPAPER
     int getPlane(void);
     int getChip(void);
     void drawSprite(const uint8_t *pSprite, int cx, int cy, int iPitch, int x, int y, uint8_t iColor);    
-#if defined (_LINUX_)
+#if defined _LINUX_ || defined _CUSTOM_IO_
     void print(const char *pString);
     void println(const char *pString);
     void print(int, int);


### PR DESCRIPTION
Specifically **WITHOUT** the Arduino framework or Linux headers.

Changes:

1. Allow a custom io header filename to be defined at compile time.
2. Don't include OS and Arduino specific headers for custom platform builds.
3. Fix duplicate symbol errors (u8Cache) with some linkers (TI).

Background:  I am trying to port the OEPL tag code to CC1310 and CC1311 based SOCs.
The TI development environment for the CC1311 only supports TIs clang compiler.

With these changes I've am able to comple bb_epaper in my project, but I haven't tested it yet.

You can find the WIP repo here if you are interested: https://github.com/skiphansen/Tag_FW_CC13xx