### PR TITLE
g5dec.inl compiles under MSVC

### DIFF
--- a/src/g5dec.inl
+++ b/src/g5dec.inl
@@ -141,7 +141,7 @@ static void Decode_Begin(G5DECIMAGE *pPage)
 #ifdef __GNUC__
 #ifdef __AVR__
     pPage->iHLen = 16 - __builtin_clz(pPage->iWidth);
-#else 
+#else
     pPage->iHLen = 32 - __builtin_clz(pPage->iWidth);
 #endif
 #else

--- a/src/g5dec.inl
+++ b/src/g5dec.inl
@@ -138,10 +138,18 @@ static void Decode_Begin(G5DECIMAGE *pPage)
     pPage->ulBits = TIFFMOTOLONG(pPage->pSrc); // load 32 bits to start
     pPage->ulBitOff = 0;
     // Calculate the number of bits needed for a long horizontal code
+#ifdef __GNUC__
 #ifdef __AVR__
     pPage->iHLen = 16 - __builtin_clz(pPage->iWidth);
-#else
+#else 
     pPage->iHLen = 32 - __builtin_clz(pPage->iWidth);
+#endif
+#else
+#ifdef _MSC_VER
+    pPage->iHLen = 32 - __lzcnt(pPage->iWidth);
+#else
+    #error "Unsupported compiler for G5 decoder"
+#endif // _MSC_VER
 #endif
 } /* Decode_Begin() */
 //


### PR DESCRIPTION
 simply added  the #ifdef to allow for g5dec.inl to compile but there are other places that uses gcc intrinsics like __builtin_bswap16 and 32 and the encoder also has a call to __builtin_clz

I used __lzcnt as a 1 to 1 replacement, and as I have a bug in my application I could not test for correctness.

_lzcnt could be off by one (not sure about that)
if found some cases that use _BitScanReverse as it seems to be dual with lzcnt
lzcnt = 31 - bsr.

