### PR TITLE
Fix what appears to be an operator precedence bug

### DIFF
--- a/src/bb_ep.inl
+++ b/src/bb_ep.inl
@@ -3094,7 +3094,7 @@ int bbepRefresh(BBEPDISP *pBBEP, int iMode)
         case REFRESH_FAST:
             if (!pBBEP->pInitFast) { // fall back to full
                 bbepSendCMDSequence(pBBEP, pBBEP->pInitFull);
-            } else if (!pBBEP->iFlags & BBEP_4COLOR) {
+            } else if (!(pBBEP->iFlags & BBEP_4COLOR)) {
                 bbepSendCMDSequence(pBBEP, pBBEP->pInitFast);
             }
             break;


### PR DESCRIPTION
It looks like this conditional is intended to be "if this is NOT a 4 color display," but the current statement would be evaluated as `(!pBBEP->iFlags) & BBEP_4COLOR` which does not match the perceived intent.