### PR TITLE
Fix compile on C compiler

### DIFF
--- a/src/bb_ep_gfx.inl
+++ b/src/bb_ep_gfx.inl
@@ -1860,7 +1860,7 @@ int bbepWriteString(BBEPDISP *pBBEP, int x, int y, char *szMsg, int iSize, int i
 //
 // Get the width of text in a custom font
 //
-void bbepGetStringBox(BBEPDISP *pBBEP, BB_FONT *pFont, const char *szMsg, int *width, int *top, int *bottom)
+void bbepGetStringBoxF(BBEPDISP *pBBEP, BB_FONT *pFont, const char *szMsg, int *width, int *top, int *bottom)
 {
     int cx = 0;
     unsigned int c, i = 0;


### PR DESCRIPTION
This PR fixes the compiling issue described in #16, by renaming one of the bbepGetStringBox function.

If you have another good name for it, I will change it.