### PR TITLE
Add Inkplate 6COLOR (EP585C_600x448) ACeP 7-color panel

### DIFF
--- a/examples/inkplate_6color_test/inkplate_6color_test.ino
+++ b/examples/inkplate_6color_test/inkplate_6color_test.ino
@@ -1,0 +1,73 @@
+// Inkplate 6COLOR (EP585C_600x448) hardware test for bb_epaper.
+//
+// Draws one horizontal bar per ACeP color, each labeled, to verify the
+// EP585C_600x448 panel entry and the u8Colors_6color remap on real hardware.
+// If every bar's fill matches its label, the panel + color mapping are correct.
+//
+// Wiring = Inkplate 6COLOR on-board ESP32 (from Inkplate6COLOR/pins.h):
+//   DC=33  RESET=19  BUSY=32  CS=27  MOSI/DIN=23  SCK/CLK=18
+//
+// The 7-color framebuffer is 600*448/2 = 134400 bytes and is allocated in
+// PSRAM, so build with PSRAM enabled, e.g.:
+//   arduino-cli compile --fqbn esp32:esp32:esp32:PSRAM=enabled \
+//       --library <path-to-bb_epaper> examples/inkplate_6color_test
+//   arduino-cli upload  --fqbn esp32:esp32:esp32:PSRAM=enabled \
+//       -p /dev/cu.usbserial-110 examples/inkplate_6color_test
+
+#include <bb_epaper.h>
+
+BBEPAPER bbep(EP585C_600x448);
+
+#define DC_PIN    33
+#define RESET_PIN 19
+#define BUSY_PIN  32
+#define CS_PIN    27
+#define MOSI_PIN  23
+#define SCK_PIN   18
+
+struct ColorBar { int fill; int text; const char *name; };
+
+static const ColorBar kBars[7] = {
+    { BBEP_BLACK,  BBEP_WHITE, "BLACK"  },
+    { BBEP_WHITE,  BBEP_BLACK, "WHITE"  },
+    { BBEP_RED,    BBEP_WHITE, "RED"    },
+    { BBEP_GREEN,  BBEP_BLACK, "GREEN"  },
+    { BBEP_BLUE,   BBEP_WHITE, "BLUE"   },
+    { BBEP_YELLOW, BBEP_BLACK, "YELLOW" },
+    { BBEP_ORANGE, BBEP_BLACK, "ORANGE" },
+};
+
+void setup()
+{
+    Serial.begin(115200);
+    delay(200);
+    Serial.println("Inkplate 6COLOR / EP585C_600x448 bb_epaper color test");
+
+    bbep.initIO(DC_PIN, RESET_PIN, BUSY_PIN, CS_PIN, MOSI_PIN, SCK_PIN);
+    if (bbep.allocBuffer() != BBEP_SUCCESS) {
+        Serial.println("ERROR: allocBuffer failed (PSRAM not enabled?)");
+        return;
+    }
+
+    bbep.fillScreen(BBEP_WHITE);
+    bbep.setFont(FONT_12x16);
+
+    const int W = 600;
+    const int barH = 64; // 7 * 64 = 448
+
+    for (int i = 0; i < 7; i++) {
+        int y = i * barH;
+        bbep.fillRect(0, y, W, barH, kBars[i].fill);
+        bbep.setTextColor(kBars[i].text, BBEP_TRANSPARENT);
+        bbep.setCursor(16, y + (barH - 16) / 2);
+        bbep.print(kBars[i].name);
+    }
+
+    Serial.println("Refreshing (full ACeP update, ~12-15 s)...");
+    bbep.writePlane();        // transmit the framebuffer to the panel (DTM 0x10 + data)
+    bbep.refresh(REFRESH_FULL);
+    bbep.sleep(DEEP_SLEEP);
+    Serial.println("Done. Check the panel: 7 labeled color bars.");
+}
+
+void loop() {}

--- a/src/bb_ep.inl
+++ b/src/bb_ep.inl
@@ -83,6 +83,21 @@ const uint8_t u8Colors_spectra[16] = {  // Spectra 6
     BBEP_BLACK, BBEP_BLACK, BBEP_BLACK, BBEP_BLACK, BBEP_BLACK, BBEP_BLACK, BBEP_BLACK, BBEP_BLACK
 };
 
+// Inkplate 6COLOR (ACeP/UC8159) uses a different native nibble order than EP73.
+// Panel nibble codes (from Inkplate6COLOR pins.h):
+//   black=0 white=1 green=2 blue=3 red=4 yellow=5 orange=6
+// This table maps a bb_epaper logical color (the index, BBEP_*) to that nibble (the value).
+const uint8_t u8Colors_6color[16] = {  // Inkplate 6COLOR ACeP 7-color
+    0, // [BBEP_BLACK]  -> 0 black
+    1, // [BBEP_WHITE]  -> 1 white
+    5, // [BBEP_YELLOW] -> 5 yellow
+    4, // [BBEP_RED]    -> 4 red
+    3, // [BBEP_BLUE]   -> 3 blue
+    2, // [BBEP_GREEN]  -> 2 green
+    6, // [BBEP_ORANGE] -> 6 orange
+    0, 0, 0, 0, 0, 0, 0, 0, 0
+};
+
 
 const uint8_t ucMirror[256] PROGMEM =
 {0, 128, 64, 192, 32, 160, 96, 224, 16, 144, 80, 208, 48, 176, 112, 240,
@@ -3603,6 +3618,27 @@ const uint8_t epd73_init[] PROGMEM = {
     BUSY_WAIT,
     0
 };
+
+// Inkplate 6COLOR (ACeP 7-color, UC8159) full init.
+// Transcribed from SolderedElectronics Inkplate-Arduino-library
+// (Inkplate6COLORDriver.cpp setPanelDeepSleep(false)). bb_epaper resets the
+// panel in bbepWakeUp() before this runs; bbepRefresh() issues DRF afterward.
+const uint8_t epd6color_init[] PROGMEM = {
+    BUSY_WAIT,                              // wait for panel ready (BUSY high) after reset
+    3, 0x00, 0xEF, 0x08,                    // PANEL_SET
+    5, 0x01, 0x37, 0x00, 0x05, 0x05,        // POWER_SET
+    2, 0x03, 0x00,                          // POWER_OFF_SEQ_SET
+    4, 0x06, 0xC7, 0xC7, 0x1D,              // BOOSTER_SOFTSTART
+    2, 0x41, 0x00,                          // TEMP_SENSOR_EN
+    2, 0x50, 0x37,                          // VCOM_DATA_INTERVAL
+    2, 0x60, 0x20,                          // TCON
+    5, 0x61, 0x02, 0x58, 0x01, 0xC0,        // RESOLUTION 600x448
+    2, 0xE3, 0xAA,                          // PWS (power saving)
+    2, 0x50, 0x37,                          // VCOM_DATA_INTERVAL (re-sent per Inkplate)
+    1, UC8151_PON,                          // power on
+    BUSY_WAIT,
+    0
+};
 // Spectra 6 (GDEP073E01) 800x480 7-color init sequence
 const uint8_t epd73_spectra_init[] PROGMEM = {
     7, 0xaa, 0x49, 0x55, 0x20, 0x08, 0x09, 0x18, // CMD H
@@ -3820,6 +3856,7 @@ const EPD_PANEL panelDefs[] PROGMEM = {
     {400, 600, 0, epd40_spectra_init, NULL, NULL, BBEP_7COLOR, BBEP_CHIP_UC81xx, u8Colors_spectra}, // EP40_SPECTRA_400x600 GDEP040E01 Spectra 6 4" 400x600
     {176, 264, 0, badger2350_init_full, badger2350_init_fast, badger2350_init_part, BBEP_NEEDS_EXTRA_INIT, BBEP_CHIP_SSD16xx, u8Colors_2clr}, // EP27_176x264
     {176, 264, 0, badger2350g_init_full, badger2350g_init_fast, NULL, BBEP_NEEDS_EXTRA_INIT | BBEP_4GRAY, BBEP_CHIP_SSD16xx, u8Colors_4gray},// EP27_176x264_4GRAY
+    {600, 448, 0, epd6color_init, NULL, NULL, BBEP_7COLOR, BBEP_CHIP_UC81xx, u8Colors_6color}, // EP585C_600x448 Inkplate 6COLOR ACeP 7-color
 };
 //
 // Set the e-paper panel type

--- a/src/bb_epaper.h
+++ b/src/bb_epaper.h
@@ -268,6 +268,7 @@ enum {
     EP40_SPECTRA_400x600, // GDEP040E01 Spectra 6 4" 400x600
     EP27_176x264, // Badger2350
     EP27_176x264_4GRAY, // Badger2350
+    EP585C_600x448, // Inkplate 6COLOR - ACeP 7-color (UC8159), 600x448
     EP_PANEL_COUNT
 };
 #ifdef FUTURE


### PR DESCRIPTION
## Summary

Adds support for the **Soldered Inkplate 6COLOR** panel — a 5.85", 600×448, 7‑color ACeP display (black/white/red/green/blue/yellow/orange) driven by a UC8159 (UC81xx family) controller.

It's the same old‑generation ACeP technology as the existing `EP73_800x480`, so this follows that entry closely:

- **`EP585C_600x448`** enum constant
- **`epd6color_init`** — full init sequence transcribed from Soldered's Inkplate‑Arduino‑library (`Inkplate6COLORDriver.cpp`), at 600×448
- **`u8Colors_6color`** — color table remapping the logical `BBEP_*` colors to the 6COLOR's native nibble codes (`green=2, blue=3, red=4, yellow=5`), which differ from `EP73`'s order
- `panelDefs` row wiring it as `BBEP_7COLOR` / `BBEP_CHIP_UC81xx`
- `examples/inkplate_6color_test` — a labeled 7‑color‑bar test sketch

## Testing

- Compiles for `esp32:esp32:esp32` via the `four_color` and new example.
- **Hardware‑verified on a real Inkplate 6COLOR**: the test sketch renders all seven colors in the correct positions matching their labels, confirming `epd6color_init` and the `u8Colors_6color` remap. (Sequence: `fillScreen`/draw → `writePlane()` → `refresh()`; the 7‑color framebuffer is allocated in PSRAM.)

## Related

- Consumed by the OpenDisplay firmware mapping in **OpenDisplay/Firmware#41**, which maps `panel_ic_type 0x0043 → EP585C_600x448`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)