### PR TITLE
Send power-off (POF) after refresh on UC81xx multi-color panels

### DIFF
--- a/src/bb_epaper.cpp
+++ b/src/bb_epaper.cpp
@@ -456,6 +456,16 @@ int BBEPAPER::refresh(int iMode, bool bWait)
     rc = bbepRefresh(&_bbep, iMode);
     if (rc == BBEP_SUCCESS && bWait) {
         bbepWaitBusy(&_bbep);
+        // UC81xx-based multi-color panels (e.g. Spectra 6 / ACeP 7-color) need a
+        // power-off (POF) after each display refresh (DRF) to properly end the
+        // frame. Without it the panel's DC/DC and source/gate drivers stay
+        // powered, and the next frame in the same power cycle misbehaves: color
+        // codes lose a bit (e.g. blue renders as white, green as yellow). Only
+        // the first frame after power-on looks correct otherwise.
+        if ((_bbep.iFlags & BBEP_7COLOR) && _bbep.chip_type == BBEP_CHIP_UC81xx) {
+            bbepWriteCmd(&_bbep, UC8151_POFF);
+            bbepWaitBusy(&_bbep);
+        }
     }
     _bbep.iOpTime = (int)(millis() - l);
     return rc;


### PR DESCRIPTION
### Problem
On UC81xx-based multi-color panels (Spectra 6 / ACeP 7-color — `BBEP_7COLOR` + `BBEP_CHIP_UC81xx`), only the **first** display update after power-on renders correctly. Every later refresh in the same power cycle renders wrong: color codes lose a bit, so blue (0x5) shows as white (0x1) and green (0x6) as yellow (0x2). Black/white/red/yellow (codes 0–3) are unaffected.
### Cause
`BBEPAPER::refresh()` sends the display refresh (`DRF`) and waits on BUSY, but never sends a power-off (`POF`). Without it the panel's DC/DC and drivers stay powered after the frame, and the next `DRF` misbehaves. The datasheet flow for these controllers is PON → DTM → DRF → BUSY → POF.
### Fix
After the BUSY wait, send `POF` (and wait BUSY) for `BBEP_7COLOR` + `BBEP_CHIP_UC81xx` panels only. Single conditional block; no change to any other panel type.
### Testing
Verified on a 7.3" Spectra 6 (800×480) panel on an ESP32-S3. Before: 2nd and later frames per power cycle rendered blue→white, green→yellow. After: all frames render correct 6-color output. The framebuffer contents were confirmed correct before the fix, so this is purely end-of-frame panel sequencing.
### Note
I got help from Claude on this.